### PR TITLE
Security: Move protect_from_forgery after authentication

### DIFF
--- a/app/controllers/blazer/base_controller.rb
+++ b/app/controllers/blazer/base_controller.rb
@@ -8,8 +8,6 @@ module Blazer
 
     clear_helpers
 
-    protect_from_forgery with: :exception
-
     if ENV["BLAZER_PASSWORD"]
       http_basic_authenticate_with name: ENV["BLAZER_USERNAME"], password: ENV["BLAZER_PASSWORD"]
     end
@@ -21,6 +19,8 @@ module Blazer
     if Blazer.before_action
       before_action Blazer.before_action.to_sym
     end
+
+    protect_from_forgery with: :exception
 
     if Blazer.override_csp
       after_action do


### PR DESCRIPTION
## Summary
- Moved `protect_from_forgery` callback to run after authentication
- Ensures proper CSRF protection order in request lifecycle

## Test plan
- [x] Verify authentication still works correctly
- [x] Test CSRF token validation
- [x] Check that protected endpoints reject forged requests