### PR TITLE
Add Rails 8.1 CI tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,8 @@ jobs:
           - ruby: "4.0"
             gemfile: Gemfile
           - ruby: 3.4
+            gemfile: gemfiles/rails81.gemfile
+          - ruby: 3.4
             gemfile: gemfiles/rails80.gemfile
           - ruby: 3.3
             gemfile: gemfiles/rails72.gemfile

--- a/gemfiles/rails81.gemfile
+++ b/gemfiles/rails81.gemfile
@@ -1,0 +1,10 @@
+source "https://rubygems.org"
+
+gemspec path: ".."
+
+gem "rake"
+gem "minitest", ">= 5"
+gem "combustion"
+gem "rails", "~> 8.1.0"
+gem "pg"
+gem "sprockets-rails"


### PR DESCRIPTION
## Summary
- Add Rails 8.1 to CI build matrix
- Create gemfiles/rails81.gemfile for testing

## Test plan
- [x] CI should run tests against Rails 8.1
- [x] All tests should pass on Rails 8.1