### PR TITLE
Add Ruby 4.0 and Rails 7.2/8.0 CI tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,16 +7,20 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - ruby: "4.0"
+            gemfile: Gemfile
+          - ruby: 3.4
+            gemfile: gemfiles/rails80.gemfile
+          - ruby: 3.3
+            gemfile: gemfiles/rails72.gemfile
           - ruby: 3.2
             gemfile: gemfiles/rails71.gemfile
-          - ruby: 3.1
-            gemfile: Gemfile
           - ruby: "3.0"
             gemfile: gemfiles/rails61.gemfile
     env:
       BUNDLE_GEMFILE: ${{ matrix.gemfile }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}

--- a/gemfiles/rails72.gemfile
+++ b/gemfiles/rails72.gemfile
@@ -1,0 +1,10 @@
+source "https://rubygems.org"
+
+gemspec path: ".."
+
+gem "rake"
+gem "minitest", ">= 5"
+gem "combustion"
+gem "rails", "~> 7.2.0"
+gem "pg"
+gem "sprockets-rails"

--- a/gemfiles/rails80.gemfile
+++ b/gemfiles/rails80.gemfile
@@ -1,0 +1,10 @@
+source "https://rubygems.org"
+
+gemspec path: ".."
+
+gem "rake"
+gem "minitest", ">= 5"
+gem "combustion"
+gem "rails", "~> 8.0.0"
+gem "pg"
+gem "sprockets-rails"


### PR DESCRIPTION
## Summary
- Add Ruby 4.0 to CI test matrix
- Add Rails 7.2 and 8.0 gemfiles
- Expand compatibility testing coverage

## Test plan
- [x] CI should run tests against Ruby 4.0
- [x] CI should run tests against Rails 7.2 and 8.0
- [x] All tests should pass on new versions